### PR TITLE
feat: support local OpenAI-compatible servers

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,9 @@ Qwen Code supports multiple API providers. You can configure your API key throug
    export OPENAI_MODEL="your_model_choice"
    ```
 
+   `OPENAI_API_KEY` is optional when connecting to local servers such as
+   Ollama or llm.cpp.
+
 2. **Project `.env` File**
    Create a `.env` file in your project root:
    ```env
@@ -109,6 +112,9 @@ Qwen Code supports multiple API providers. You can configure your API key throug
    OPENAI_BASE_URL=your_api_endpoint
    OPENAI_MODEL=your_model_choice
    ```
+
+   `OPENAI_API_KEY` may be omitted when using local servers like Ollama or
+   llm.cpp.
 
 #### API Provider Options
 
@@ -158,6 +164,26 @@ export OPENAI_MODEL="qwen3-coder-plus"
 export OPENAI_API_KEY="your_api_key_here"
 export OPENAI_BASE_URL="https://openrouter.ai/api/v1"
 export OPENAI_MODEL="qwen/qwen3-coder:free"
+```
+
+</details>
+
+<details>
+<summary><b>🖥️ Local On-Prem Servers</b></summary>
+
+No API key required. Ensure your server exposes an OpenAI-compatible API.
+
+```bash
+# Ollama
+qwen --ollama --model your_model
+
+# llama.cpp
+qwen --llmcpp --model your_model
+
+# or set the base URL manually
+export OPENAI_BASE_URL="http://localhost:11434/v1"  # Ollama
+export OPENAI_BASE_URL="http://localhost:8080/v1"   # llama.cpp
+export OPENAI_MODEL="your_model"
 ```
 
 </details>

--- a/docs/cli/openai-auth.md
+++ b/docs/cli/openai-auth.md
@@ -8,13 +8,13 @@ Qwen Code CLI supports OpenAI authentication for users who want to use OpenAI mo
 
 When you first run the CLI and select OpenAI as your authentication method, you'll be prompted to enter:
 
-- **API Key**: Your OpenAI API key from [https://platform.openai.com/api-keys](https://platform.openai.com/api-keys)
+- **API Key**: Your OpenAI API key from [https://platform.openai.com/api-keys](https://platform.openai.com/api-keys) (optional for local servers)
 - **Base URL**: The base URL for OpenAI API (defaults to `https://api.openai.com/v1`)
 - **Model**: The OpenAI model to use (defaults to `gpt-4o`)
 
 The CLI will guide you through each field:
 
-1. Enter your API key and press Enter
+1. Enter your API key (or leave blank for local servers) and press Enter
 2. Review/modify the base URL and press Enter
 3. Review/modify the model name and press Enter
 
@@ -63,6 +63,25 @@ You can use custom endpoints by setting the `OPENAI_BASE_URL` environment variab
 - Using Azure OpenAI
 - Using other OpenAI-compatible APIs
 - Using local OpenAI-compatible servers
+
+### Local Servers (Ollama or llm.cpp)
+
+No API key is required when connecting to local servers. You can either set the
+base URL manually:
+
+```bash
+# Ollama default
+export OPENAI_BASE_URL="http://localhost:11434/v1"
+# llama.cpp default
+export OPENAI_BASE_URL="http://localhost:8080/v1"
+```
+
+or use the built-in flags:
+
+```bash
+qwen --ollama --model your_model
+qwen --llmcpp --model your_model
+```
 
 ## Switching Authentication Methods
 

--- a/packages/cli/src/config/auth.ts
+++ b/packages/cli/src/config/auth.ts
@@ -39,8 +39,8 @@ export const validateAuthMethod = (authMethod: string): string | null => {
   }
 
   if (authMethod === AuthType.USE_OPENAI) {
-    if (!process.env.OPENAI_API_KEY) {
-      return 'OPENAI_API_KEY environment variable not found. You can enter it interactively or add it to your .env file.';
+    if (!process.env.OPENAI_API_KEY && !process.env.OPENAI_BASE_URL) {
+      return 'OPENAI_API_KEY or OPENAI_BASE_URL environment variable not found. Provide an API key or set OPENAI_BASE_URL for a local server.';
     }
     return null;
   }

--- a/packages/cli/src/config/config.ts
+++ b/packages/cli/src/config/config.ts
@@ -66,6 +66,8 @@ export interface CliArgs {
   openaiLogging: boolean | undefined;
   openaiApiKey: string | undefined;
   openaiBaseUrl: string | undefined;
+  ollama: boolean | undefined;
+  llmcpp: boolean | undefined;
   proxy: string | undefined;
   includeDirectories: string[] | undefined;
 }
@@ -214,6 +216,16 @@ export async function parseArguments(): Promise<CliArgs> {
       type: 'string',
       description: 'OpenAI base URL (for custom endpoints)',
     })
+    .option('ollama', {
+      type: 'boolean',
+      description:
+        'Use local Ollama server (sets OPENAI_BASE_URL to http://localhost:11434/v1)',
+    })
+    .option('llmcpp', {
+      type: 'boolean',
+      description:
+        'Use local llm.cpp server (sets OPENAI_BASE_URL to http://localhost:8080/v1)',
+    })
     .option('proxy', {
       type: 'string',
       description:
@@ -326,6 +338,14 @@ export async function loadCliConfig(
   // Handle OpenAI base URL from command line
   if (argv.openaiBaseUrl) {
     process.env.OPENAI_BASE_URL = argv.openaiBaseUrl;
+  }
+
+  if (argv.ollama) {
+    process.env.OPENAI_BASE_URL = 'http://localhost:11434/v1';
+  }
+
+  if (argv.llmcpp) {
+    process.env.OPENAI_BASE_URL = 'http://localhost:8080/v1';
   }
 
   // Set the context filename in the server's memoryTool module BEFORE loading memory

--- a/packages/cli/src/ui/components/OpenAIKeyPrompt.test.tsx
+++ b/packages/cli/src/ui/components/OpenAIKeyPrompt.test.tsx
@@ -17,7 +17,7 @@ describe('OpenAIKeyPrompt', () => {
       <OpenAIKeyPrompt onSubmit={onSubmit} onCancel={onCancel} />,
     );
 
-    expect(lastFrame()).toContain('OpenAI Configuration Required');
+    expect(lastFrame()).toContain('OpenAI Configuration');
     expect(lastFrame()).toContain('https://platform.openai.com/api-keys');
     expect(lastFrame()).toContain(
       'Press Enter to continue, Tab/↑↓ to navigate, Esc to cancel',
@@ -33,7 +33,7 @@ describe('OpenAIKeyPrompt', () => {
     );
 
     const output = lastFrame();
-    expect(output).toContain('OpenAI Configuration Required');
+    expect(output).toContain('OpenAI Configuration');
     expect(output).toContain('API Key:');
     expect(output).toContain('Base URL:');
     expect(output).toContain('Model:');

--- a/packages/cli/src/ui/components/OpenAIKeyPrompt.tsx
+++ b/packages/cli/src/ui/components/OpenAIKeyPrompt.tsx
@@ -63,13 +63,7 @@ export function OpenAIKeyPrompt({
         setCurrentField('model');
         return;
       } else if (currentField === 'model') {
-        // 只有在提交时才检查 API key 是否为空
-        if (apiKey.trim()) {
-          onSubmit(apiKey.trim(), baseUrl.trim(), model.trim());
-        } else {
-          // 如果 API key 为空，回到 API key 字段
-          setCurrentField('apiKey');
-        }
+        onSubmit(apiKey.trim(), baseUrl.trim(), model.trim());
       }
       return;
     }
@@ -131,12 +125,11 @@ export function OpenAIKeyPrompt({
       padding={1}
       width="100%"
     >
-      <Text bold color={Colors.AccentBlue}>
-        OpenAI Configuration Required
-      </Text>
+      <Text bold color={Colors.AccentBlue}>OpenAI Configuration</Text>
       <Box marginTop={1}>
         <Text>
-          Please enter your OpenAI configuration. You can get an API key from{' '}
+          Please enter your OpenAI configuration. API key is optional for local
+          servers like Ollama or llm.cpp. You can get an API key from{' '}
           <Text color={Colors.AccentBlue}>
             https://platform.openai.com/api-keys
           </Text>

--- a/packages/cli/src/validateNonInterActiveAuth.test.ts
+++ b/packages/cli/src/validateNonInterActiveAuth.test.ts
@@ -122,6 +122,19 @@ describe('validateNonInterActiveAuth', () => {
     expect(refreshAuthMock).toHaveBeenCalledWith(AuthType.USE_OPENAI);
   });
 
+  it('uses USE_OPENAI if OPENAI_BASE_URL is set', async () => {
+    process.env.OPENAI_BASE_URL = 'http://localhost:11434/v1';
+    const nonInteractiveConfig: NonInteractiveConfig = {
+      refreshAuth: refreshAuthMock,
+    };
+    await validateNonInteractiveAuth(
+      undefined,
+      undefined,
+      nonInteractiveConfig,
+    );
+    expect(refreshAuthMock).toHaveBeenCalledWith(AuthType.USE_OPENAI);
+  });
+
   it('uses USE_VERTEX_AI if GOOGLE_GENAI_USE_VERTEXAI is true (with GOOGLE_CLOUD_PROJECT and GOOGLE_CLOUD_LOCATION)', async () => {
     process.env.GOOGLE_GENAI_USE_VERTEXAI = 'true';
     process.env.GOOGLE_CLOUD_PROJECT = 'test-project';

--- a/packages/cli/src/validateNonInterActiveAuth.ts
+++ b/packages/cli/src/validateNonInterActiveAuth.ts
@@ -18,7 +18,7 @@ function getAuthTypeFromEnv(): AuthType | undefined {
   if (process.env.GEMINI_API_KEY) {
     return AuthType.USE_GEMINI;
   }
-  if (process.env.OPENAI_API_KEY) {
+  if (process.env.OPENAI_API_KEY || process.env.OPENAI_BASE_URL) {
     return AuthType.USE_OPENAI;
   }
   return undefined;

--- a/packages/core/src/core/contentGenerator.ts
+++ b/packages/core/src/core/contentGenerator.ts
@@ -123,8 +123,8 @@ export function createContentGeneratorConfig(
     return contentGeneratorConfig;
   }
 
-  if (authType === AuthType.USE_OPENAI && openaiApiKey) {
-    contentGeneratorConfig.apiKey = openaiApiKey;
+  if (authType === AuthType.USE_OPENAI) {
+    contentGeneratorConfig.apiKey = openaiApiKey || '';
     contentGeneratorConfig.model =
       process.env.OPENAI_MODEL || DEFAULT_GEMINI_MODEL;
 
@@ -171,17 +171,17 @@ export async function createContentGenerator(
   }
 
   if (config.authType === AuthType.USE_OPENAI) {
-    if (!config.apiKey) {
-      throw new Error('OpenAI API key is required');
-    }
-
     // Import OpenAIContentGenerator dynamically to avoid circular dependencies
     const { OpenAIContentGenerator } = await import(
       './openaiContentGenerator.js'
     );
 
     // Always use OpenAIContentGenerator, logging is controlled by enableOpenAILogging flag
-    return new OpenAIContentGenerator(config.apiKey, config.model, gcConfig);
+    return new OpenAIContentGenerator(
+      config.apiKey || '',
+      config.model,
+      gcConfig,
+    );
   }
 
   throw new Error(


### PR DESCRIPTION
## Summary
- allow OpenAI auth when only OPENAI_BASE_URL is set
- add `--ollama` and `--llmcpp` flags for local servers
- document connecting to local servers without an API key

## Testing
- `npm test` *(fails: packages/core/src/tools/edit.test.ts should return FILE_WRITE_FAILURE on write error)*

------
https://chatgpt.com/codex/tasks/task_e_6895a186add883298992951a5a0fd7fb